### PR TITLE
Address `jq: Argument list too long`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -98,10 +98,7 @@ runs:
             # exclude these entries as we only want jobs which have actually executed.
             attempt_jobs="$(jq 'map(select(.completed_at == null or .completed_at >= .created_at))' <<<"${attempt_jobs}")"
 
-            jobs="$(jq -e 'add' <<<"${jobs}" <<<"${attempt_jobs}")"
-
-            echo "jobs"
-            jq . <<<"$jobs"
+            jobs="$(jq -s 'add' <<<"${jobs}" <<<"${attempt_jobs}")"
         done
 
         # Remove older jobs which were re-run

--- a/action.yaml
+++ b/action.yaml
@@ -85,7 +85,6 @@ runs:
       shell: bash
       run: |
         # Determine executed jobs
-        set -x
 
         # Fetch the jobs for the current and all previous run attempts. We are not using
         # the GitHub API endpoint `/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?filter=all`
@@ -100,6 +99,9 @@ runs:
             attempt_jobs="$(jq 'map(select(.completed_at == null or .completed_at >= .created_at))' <<<"${attempt_jobs}")"
 
             jobs="$(jq -e 'add' <<<"${jobs}" <<<"${attempt_jobs}")"
+
+            echo "jobs"
+            jq . <<<"$jobs"
         done
 
         # Remove older jobs which were re-run

--- a/action.yaml
+++ b/action.yaml
@@ -85,6 +85,7 @@ runs:
       shell: bash
       run: |
         # Determine executed jobs
+        set -x
 
         # Fetch the jobs for the current and all previous run attempts. We are not using
         # the GitHub API endpoint `/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?filter=all`

--- a/action.yaml
+++ b/action.yaml
@@ -98,7 +98,7 @@ runs:
             # exclude these entries as we only want jobs which have actually executed.
             attempt_jobs="$(jq 'map(select(.completed_at == null or .completed_at >= .created_at))' <<<"${attempt_jobs}")"
 
-            jobs="$(jq -e --argjson attempt_jobs "${attempt_jobs}" '. |= . + $attempt_jobs' <<<"$jobs")"
+            jobs="$(jq -e 'add' <<<"${jobs}" <<<"${attempt_jobs}")"
         done
 
         # Remove older jobs which were re-run


### PR DESCRIPTION
I noticed this in a workflow that had quite a view jobs in it that failed:
```
 Run # Determine executed jobs
  # Determine executed jobs
  
  # Fetch the jobs for the current and all previous run attempts. We are not using
  # the GitHub API endpoint `/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?filter=all`
  # here as it has proven to be unreliable and does not include running jobs.
  jobs='[]'
  for attempt in $(seq 1 ${run_attempt}); do
      attempt_jobs="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${attempt:?}/jobs" --jq '.jobs')"
  
      # Remove job entries which weren't actually executed during this attempt.
      # The GitHub API includes new `job_id`s for each `run_attempt` and we want to
      # exclude these entries as we only want jobs which have actually executed.
      attempt_jobs="$(jq 'map(select(.completed_at == null or .completed_at >= .created_at))' <<<"${attempt_jobs}")"
  
      jobs="$(jq -e --argjson attempt_jobs "${attempt_jobs}" '. |= . + $attempt_jobs' <<<"$jobs")"
  done
  
  # Remove older jobs which were re-run
  jobs="$(jq 'sort_by(.created_at) | reverse | unique_by(.name)' <<<"${jobs}")"
  
  if [[ "$RUNNER_DEBUG" -eq 1 ]] || [[ "false" == "true" ]]; then
      echo "Executed jobs:" >&2
      jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}" >&2
  fi
  
  {
      echo "json<<EOF"
      jq '.' <<<"${jobs}"
      echo "EOF"
  } >>"$GITHUB_OUTPUT"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    ...
    run_id: 19545453192
    run_attempt: 5
/home/runner/work/_temp/41172944-f1f5-4475-8072-c3b069ff0761.sh: line 15: /usr/bin/jq: Argument list too long
Error: Process completed with exit code 126.
```

I attempted to reproduce this failure locally but was not able to. The total number of jobs for all attempts was 40.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212004972288582