### PR TITLE
Update job-context version & avoid overly long argument lists

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,13 +64,8 @@ runs:
             jq '.' <<<"${jobs}" >&2
         fi
 
-        # Specify our multiline output using GH action flavored heredocs
-        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-        {
-            echo "json<<EOF"
-            jq '.' <<<"${jobs}"
-            echo "EOF"
-        } >>"$GITHUB_OUTPUT"
+        # Store job list in a file
+        echo $jobs > ${{ runner.temp }}/artifact-jobs.json
       env:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
@@ -110,11 +105,8 @@ runs:
             jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}" >&2
         fi
 
-        {
-            echo "json<<EOF"
-            jq '.' <<<"${jobs}"
-            echo "EOF"
-        } >>"$GITHUB_OUTPUT"
+        # Store job list in a file
+        echo $jobs > ${{ runner.temp }}/executed-jobs.json
       env:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
@@ -124,8 +116,11 @@ runs:
       id: matrix-jobs
       shell: bash
       run: |
+        # Read artifact jobs
+        artifact_jobs="$(jq '.' < ${{ runner.temp }}/artifact-jobs.json)"
+
         # Determine matrix jobs
-        executed_jobs="$(jq '[.[] | {id, name, conclusion}]' <<<"${executed_jobs:?}")"
+        executed_jobs="$(jq '[.[] | {id, name, conclusion}]' < ${{ runner.temp }}/executed-jobs.json)"
 
         # Combine the `executed_jobs` into the `artifact_jobs` data (left join) to produce list of jobs in the matrix.
         # For more info on `jq`'s SQL style JOIN see: https://qmacro.org/blog/posts/2022/06/23/understanding-jq%27s-sql-style-operators-join-and-index/
@@ -153,8 +148,6 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
-        artifact_jobs: ${{ steps.artifact-jobs.outputs.json }}
-        executed_jobs: ${{ steps.executed-jobs.outputs.json }}
     - name: Upload sync artifact
       uses: actions/upload-artifact@v5
       if: ${{ steps.matrix-jobs.outputs.num == strategy.job-total && steps.matrix-jobs.outputs.num-running > 1 }}

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - id: job
-      uses: beacon-biosignals/job-context@656c4f5d624c5e6b5679e742c179f5f6da90b02d  # v1.1.1
+      uses: beacon-biosignals/job-context@2f92656dba435815b1248b58e472f8721fb8a448 # v1.1.2
     - name: Generate job output
       shell: bash
       run: |


### PR DESCRIPTION
Hello! Couple of changes here, firstly to use the new job-context version, and also to dump the list of jobs to a temporary file rather than saving them as an env var as the latter can lead to Bash errors with overly long argument lists. (Here's an example of a CI workflow demonstrating the error, where I run around 50 jobs in parallel: https://github.com/TuringLang/ADTests/actions/runs/20696688004/job/59413511784 -- the error is fixed by this PR.)