### PR TITLE
Improve support for large job matrix

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -238,6 +238,9 @@ jobs:
   # Workflow which contain a large number of jobs may run into "bash: Argument list too long"
   # if we haven't reduced the job content internally. If this occurs failures may also occur
   # on other integration tests.
+  # 
+  # Having the number of jobs exceed 100 forces pagination to occur which takes some special
+  # handling
   setup-large:
     name: Setup Large
     runs-on: ubuntu-latest
@@ -250,7 +253,7 @@ jobs:
           matrix='{"job": []}'
           # Maximum allowed number of jobs is 256:
           # "Strategy for job 'exec-large' produced N configurations which exceeds the maximum of 256 configurations"
-          for i in {1..256}; do
+          for i in {1..101}; do
             # Include a UUID to artificially increase the job name length
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -247,9 +247,17 @@ jobs:
     steps:
       - id: matrix
         run: |
-          matrix='{"index": []}'
+          matrix='{"job": []}'
           for i in {1..30}; do
-            matrix="$(jq --arg index "${index}" '.index += [$index]' <<<"${matrix}")"
+            # Include a UUID to artificially increase the job name length
+            uuid="$(cat /proc/sys/kernel/random/uuid)"
+            matrix="$(
+              jq \
+              --arg index "${index}" \
+              --arg uuid "${uuid}" \
+              '.job += {index: $index, uuid: $uuid}' \
+              <<<"${matrix}"
+            )"
           done
 
           {
@@ -259,7 +267,7 @@ jobs:
           } | tee -a "$GITHUB_OUTPUT"
 
   exec-large:
-    name: Execute Large
+    name: Execute Large (${{ matrix.job.index }}, ${{ matrix.job.uuid }})
     needs: setup-large
     runs-on: ubuntu-latest
     permissions:
@@ -276,7 +284,8 @@ jobs:
         id: matrix-output
         with:
           yaml: |
-            index: ${{ matrix.index }}
+            index: ${{ matrix.job.index }}
+            uuid: ${{ matrix.job.uuid }}
           debug: true
 
   test-large:
@@ -289,7 +298,7 @@ jobs:
       - name: Expected JSON
         id: expected
         run: |
-          json="$(jq '.index | map({index: .})' <<<"${matrix}")"
+          json="$(jq '.job | map({.index, .uuid})' <<<"${matrix}")"
           {
             echo "json<<EOF"
             jq '.' <<<"${json}"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -298,7 +298,7 @@ jobs:
       - name: Expected JSON
         id: expected
         run: |
-          json="$(jq '.job | map({.index, .uuid})' <<<"${matrix}")"
+          json="$(jq '.job | map({index, uuid})' <<<"${matrix}")"
           {
             echo "json<<EOF"
             jq '.' <<<"${json}"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -309,7 +309,7 @@ jobs:
       - name: Output JSON
         run: |
           # Order of output is based upon matrix execution not matrix order
-          output_json="$(jq '.job | {job: sort_by(.index)}' <<<"${output_json}")"
+          output_json="$(jq 'sort_by(.index)}' <<<"${output_json}")"
 
           if [[ "${output_json}" != "${expected_json}" ]]; then
               cat <<<"${output_json}" >"output"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -184,7 +184,7 @@ jobs:
           exit 1
 
   exec-race-condition:
-    name: ExecuteRace Condition
+    name: Execute Race Condition
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -274,24 +274,27 @@ jobs:
         id: matrix-output
         with:
           yaml: |
-            index: ${{ matrix.index }}
+            uuid: ${{ matrix.uuid }}
           debug: true
 
   test-large:
     name: Test Large
-    needs: exec-large
+    needs:
+      - setup-large
+      - exec-large
     runs-on: ubuntu-latest
     steps:
       - name: Expected JSON
         id: expected
         run: |
-          json="$(jq -n '[range(1; 51)] | map({index: .})')"
-
+          json="$(jq '.uuid | map({uuid: .})' <<<"${matrix}")"
           {
             echo "json<<EOF"
             jq '.' <<<"${json}"
             echo "EOF"
           } >>"$GITHUB_OUTPUT"
+        env:
+          matrix: ${{ needs.setup-large.outputs.matrix-json }}
       - name: Output JSON
         run: |
           if [[ "${output_json}" != "${expected_json}" ]]; then
@@ -301,5 +304,5 @@ jobs:
               exit 1
           fi
         env:
-          output_json: ${{ needs.exec-race-condition.outputs.results-json }}
+          output_json: ${{ needs.exec-large.outputs.results-json }}
           expected_json: ${{ steps.expected.outputs.json}}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -235,6 +235,9 @@ jobs:
               }
             ]
 
+  # Workflow which contain a large number of jobs may run into "bash: Argument list too long"
+  # if we haven't reduced the job content internally. If this occurs failures may also occur
+  # on other integration tests.
   setup-large:
     name: Setup Large
     runs-on: ubuntu-latest
@@ -244,10 +247,9 @@ jobs:
     steps:
       - id: matrix
         run: |
-          matrix='{"uuid": []}'
+          matrix='{"index": []}'
           for i in {1..30}; do
-            uuid="$(cat /proc/sys/kernel/random/uuid)"
-            matrix="$(jq --arg uuid "${uuid}" '.uuid += [$uuid]' <<<"${matrix}")"
+            matrix="$(jq --arg index "${index}" '.index += [$index]' <<<"${matrix}")"
           done
 
           {
@@ -274,7 +276,7 @@ jobs:
         id: matrix-output
         with:
           yaml: |
-            uuid: ${{ matrix.uuid }}
+            index: ${{ matrix.index }}
           debug: true
 
   test-large:
@@ -287,7 +289,7 @@ jobs:
       - name: Expected JSON
         id: expected
         run: |
-          json="$(jq '.uuid | map({uuid: .})' <<<"${matrix}")"
+          json="$(jq '.index | map({index: .})' <<<"${matrix}")"
           {
             echo "json<<EOF"
             jq '.' <<<"${json}"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -248,7 +248,7 @@ jobs:
       - id: matrix
         run: |
           matrix='{"job": []}'
-          for i in {1..40}; do
+          for i in {1..50}; do
             # Include a UUID to artificially increase the job name length
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -248,7 +248,7 @@ jobs:
       - id: matrix
         run: |
           matrix='{"job": []}'
-          for i in {1..50}; do
+          for i in {1..40}; do
             # Include a UUID to artificially increase the job name length
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -265,7 +265,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.setup-large.outputs.json) }}
+      matrix: ${{ fromJSON(needs.setup-large.outputs.matrix-json) }}
     outputs:
       results-json: ${{ steps.matrix-output.outputs.json }}
     steps:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -7,8 +7,8 @@ on:
       - ".github/workflows/integration-tests.yaml"
 
 jobs:
-  setup-simple:
-    name: Setup Simple
+  exec-simple:
+    name: Execute Simple
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -26,7 +26,7 @@ jobs:
       # Slow down on job to ensure that this is the last run
       - if: ${{ strategy.job-index == 0 }}
         run: sleep 5
-      # Keep `id` the same between `setup-simple` and `setup-complex`
+      # Keep `id` the same between `exec-simple` and `exec-complex`
       # to ensure we can separate output per job.
       - uses: ./
         id: matrix-output
@@ -37,7 +37,7 @@ jobs:
 
   test-simple:
     name: Test Simple
-    needs: setup-simple
+    needs: exec-simple
     runs-on: ubuntu-latest
     steps:
       - name: Output JSON
@@ -49,7 +49,7 @@ jobs:
               exit 1
           fi
         env:
-          output_json: ${{ needs.setup-simple.outputs.results-json }}
+          output_json: ${{ needs.exec-simple.outputs.results-json }}
           expected_json: |-
             [
               {
@@ -60,8 +60,8 @@ jobs:
               }
             ]
 
-  setup-complex:
-    name: Setup Complex
+  exec-complex:
+    name: Execute Complex
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -81,7 +81,7 @@ jobs:
       results-json: ${{ steps.matrix-output.outputs.json }}
     steps:
       - uses: actions/checkout@v5
-      # Keep `id` the same between `setup-simple` and `setup-complex`
+      # Keep `id` the same between `exec-simple` and `exec-complex`
       # to ensure we can separate output per job.
       - uses: ./
         id: matrix-output
@@ -95,7 +95,7 @@ jobs:
 
   test-complex:
     name: Test Complex
-    needs: setup-complex
+    needs: exec-complex
     runs-on: ubuntu-latest
     steps:
       - name: Output JSON
@@ -107,7 +107,7 @@ jobs:
               exit 1
           fi
         env:
-          output_json: ${{ needs.setup-complex.outputs.results-json }}
+          output_json: ${{ needs.exec-complex.outputs.results-json }}
           expected_json: |-
             [
               {
@@ -183,8 +183,8 @@ jobs:
           echo "matrix-output2: ${{ steps.matrix-output2.outcome }}" >&2
           exit 1
 
-  setup-race-condition:
-    name: Setup Race Condition
+  exec-race-condition:
+    name: ExecuteRace Condition
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -212,7 +212,7 @@ jobs:
 
   test-race-condition:
     name: Test Race Condition
-    needs: setup-race-condition
+    needs: exec-race-condition
     runs-on: ubuntu-latest
     steps:
       - name: Output JSON
@@ -224,7 +224,7 @@ jobs:
               exit 1
           fi
         env:
-          output_json: ${{ needs.setup-race-condition.outputs.results-json }}
+          output_json: ${{ needs.exec-race-condition.outputs.results-json }}
           expected_json: |-
             [
               {

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -253,9 +253,9 @@ jobs:
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(
               jq \
-              --arg index "${index}" \
+              --argjson index "$i" \
               --arg uuid "${uuid}" \
-              '.job += {index: $index, uuid: $uuid}' \
+              '.job += [{index: $index, uuid: $uuid}]' \
               <<<"${matrix}"
             )"
           done

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -254,7 +254,7 @@ jobs:
           # Maximum allowed number of jobs is 256:
           # "Strategy for job 'exec-large' produced N configurations which exceeds the maximum of 256 configurations"
           #
-          # We choose the number 101 here to ensure we at least over 101 jobs which ensures
+          # We choose the number 101 here to ensure we at least over 100 jobs which ensures
           # that any queries targeting this workflow run must use pagination.
           for i in {1..101}; do
             # Include a UUID to artificially increase the job name length

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -238,7 +238,7 @@ jobs:
   # Workflow which contain a large number of jobs may run into "bash: Argument list too long"
   # if we haven't reduced the job content internally. If this occurs failures may also occur
   # on other integration tests.
-  # 
+  #
   # Having the number of jobs exceed 100 forces pagination to occur which takes some special
   # handling
   setup-large:
@@ -313,9 +313,6 @@ jobs:
           matrix: ${{ needs.setup-large.outputs.matrix-json }}
       - name: Output JSON
         run: |
-          # Order of output is based upon matrix execution not matrix order
-          output_json="$(jq 'sort_by(.index)' <<<"${output_json}")"
-
           if [[ "${output_json}" != "${expected_json}" ]]; then
               cat <<<"${output_json}" >"output"
               cat <<<"${expected_json}" >"expected"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -248,7 +248,9 @@ jobs:
       - id: matrix
         run: |
           matrix='{"job": []}'
-          for i in {1..500}; do
+          # Maximum allowed number of jobs is 256:
+          # "Strategy for job 'exec-large' produced N configurations which exceeds the maximum of 256 configurations"
+          for i in {1..256}; do
             # Include a UUID to artificially increase the job name length
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -248,7 +248,7 @@ jobs:
       - id: matrix
         run: |
           matrix='{"job": []}'
-          for i in {1..50}; do
+          for i in {1..500}; do
             # Include a UUID to artificially increase the job name length
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -245,7 +245,7 @@ jobs:
       - id: matrix
         run: |
           matrix='{"uuid": []}'
-          for i in {1..50}; do
+          for i in {1..30}; do
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(jq --arg uuid "${uuid}" '.uuid += [$uuid]' <<<"${matrix}")"
           done

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -308,6 +308,9 @@ jobs:
           matrix: ${{ needs.setup-large.outputs.matrix-json }}
       - name: Output JSON
         run: |
+          # Order of output is based upon matrix execution not matrix order
+          output_json=$(jq '.job | {job: sort_by(.index)}' <<<"${output_json}")"
+
           if [[ "${output_json}" != "${expected_json}" ]]; then
               cat <<<"${output_json}" >"output"
               cat <<<"${expected_json}" >"expected"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -309,7 +309,7 @@ jobs:
       - name: Output JSON
         run: |
           # Order of output is based upon matrix execution not matrix order
-          output_json=$(jq '.job | {job: sort_by(.index)}' <<<"${output_json}")"
+          output_json="$(jq '.job | {job: sort_by(.index)}' <<<"${output_json}")"
 
           if [[ "${output_json}" != "${expected_json}" ]]; then
               cat <<<"${output_json}" >"output"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -248,7 +248,7 @@ jobs:
       - id: matrix
         run: |
           matrix='{"job": []}'
-          for i in {1..30}; do
+          for i in {1..50}; do
             # Include a UUID to artificially increase the job name length
             uuid="$(cat /proc/sys/kernel/random/uuid)"
             matrix="$(

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -284,7 +284,7 @@ jobs:
     outputs:
       results-json: ${{ steps.matrix-output.outputs.json }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./
         id: matrix-output
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -309,7 +309,7 @@ jobs:
       - name: Output JSON
         run: |
           # Order of output is based upon matrix execution not matrix order
-          output_json="$(jq 'sort_by(.index)}' <<<"${output_json}")"
+          output_json="$(jq 'sort_by(.index)' <<<"${output_json}")"
 
           if [[ "${output_json}" != "${expected_json}" ]]; then
               cat <<<"${output_json}" >"output"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -253,6 +253,9 @@ jobs:
           matrix='{"job": []}'
           # Maximum allowed number of jobs is 256:
           # "Strategy for job 'exec-large' produced N configurations which exceeds the maximum of 256 configurations"
+          #
+          # We choose the number 101 here to ensure we at least over 101 jobs which ensures
+          # that any queries targeting this workflow run must use pagination.
           for i in {1..101}; do
             # Include a UUID to artificially increase the job name length
             uuid="$(cat /proc/sys/kernel/random/uuid)"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -234,3 +234,72 @@ jobs:
                 "index": 2
               }
             ]
+
+  setup-large:
+    name: Setup Large
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      matrix-json: ${{ steps.matrix.outputs.json }}
+    steps:
+      - id: matrix
+        run: |
+          matrix='{"uuid": []}'
+          for i in {1..50}; do
+            uuid="$(cat /proc/sys/kernel/random/uuid)"
+            matrix="$(jq --arg uuid "${uuid}" '.uuid += [$uuid]' <<<"${matrix}")"
+          done
+
+          {
+            echo "json<<EOF"
+            jq '.' <<<"${matrix}"
+            echo "EOF"
+          } | tee -a "$GITHUB_OUTPUT"
+
+  exec-large:
+    name: Execute Large
+    needs: setup-large
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup-large.outputs.json) }}
+    outputs:
+      results-json: ${{ steps.matrix-output.outputs.json }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./
+        id: matrix-output
+        with:
+          yaml: |
+            index: ${{ matrix.index }}
+          debug: true
+
+  test-large:
+    name: Test Large
+    needs: exec-large
+    runs-on: ubuntu-latest
+    steps:
+      - name: Expected JSON
+        id: expected
+        run: |
+          json="$(jq -n '[range(1; 51)] | map({index: .})')"
+
+          {
+            echo "json<<EOF"
+            jq '.' <<<"${json}"
+            echo "EOF"
+          } >>"$GITHUB_OUTPUT"
+      - name: Output JSON
+        run: |
+          if [[ "${output_json}" != "${expected_json}" ]]; then
+              cat <<<"${output_json}" >"output"
+              cat <<<"${expected_json}" >"expected"
+              diff output expected | cat -te
+              exit 1
+          fi
+        env:
+          output_json: ${{ needs.exec-race-condition.outputs.results-json }}
+          expected_json: ${{ steps.expected.outputs.json}}

--- a/action.yaml
+++ b/action.yaml
@@ -32,13 +32,14 @@ runs:
       run: |
         input_json="$(yq -o=json <<<"${input_yaml:?}")"
         jq -ne \
-            --argjson metadata "{\"job-id\": ${self_job_id:?}}" \
+            --argjson metadata "{\"job-id\": ${self_job_id:?}, \"job-index\": ${self_job_index:?}}" \
             --argjson outputs "${input_json:?}" \
             '$ARGS.named' | tee -a job-output.json
         touch job-sync
       env:
         input_yaml: ${{ inputs.yaml }}
         self_job_id: ${{ steps.job.outputs.id }}
+        self_job_index: ${{ strategy.job-index }}
     - name: Upload job output
       uses: actions/upload-artifact@v5
       with:
@@ -57,7 +58,7 @@ runs:
       run: |
         # Determine artifact jobs
         shopt -s globstar
-        jobs="$(jq -rs '[.[].metadata."job-id"] | to_entries | map({id: .value, index: .key})' matrix-output/**/*.json)"
+        jobs="$(jq -rs '[.[].metadata] | map({id: ."job-id", index: ."job-index"})' matrix-output/**/*.json)"
 
         if [[ "$RUNNER_DEBUG" -eq 1 ]] || [[ "${{ inputs.debug }}" == "true" ]]; then
             echo "Artifact jobs:" >&2

--- a/action.yaml
+++ b/action.yaml
@@ -226,6 +226,6 @@ runs:
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         {
             echo "json<<EOF"
-            jq -s '[.[].outputs]' matrix-output/**/*.json
+            jq -s 'sort_by(.metadata."job-index") | [.[].outputs]' matrix-output/**/*.json
             echo "EOF"
         } | tee -a "$GITHUB_OUTPUT"

--- a/action.yaml
+++ b/action.yaml
@@ -165,6 +165,7 @@ runs:
       if: ${{ steps.matrix-jobs.outputs.num == strategy.job-total && steps.matrix-jobs.outputs.num-running > 1 }}
       shell: bash
       run: |
+        set -x
         # Wait for running matrix jobs
         start=$(date +%s)
 

--- a/action.yaml
+++ b/action.yaml
@@ -105,9 +105,12 @@ runs:
         # Remove older jobs which were re-run
         jobs="$(jq 'sort_by(.created_at) | reverse | unique_by(.name)' <<<"${jobs}")"
 
+        # Reduce size of executed jobs content
+        jobs="$(jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}")"
+
         if [[ "$RUNNER_DEBUG" -eq 1 ]] || [[ "${{ inputs.debug }}" == "true" ]]; then
             echo "Executed jobs:" >&2
-            jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}" >&2
+            jq '.' <<<"${jobs}" >&2
         fi
 
         {

--- a/action.yaml
+++ b/action.yaml
@@ -26,8 +26,7 @@ runs:
   using: composite
   steps:
     - id: job
-      # uses: beacon-biosignals/job-context@2f92656dba435815b1248b58e472f8721fb8a448 # v1.1.2
-      uses: beacon-biosignals/job-context@6cdc430ffafdf7b69d31fa7442f30de07e88cc77 # https://github.com/beacon-biosignals/job-context/pull/16
+      uses: beacon-biosignals/job-context@1978ffa0bc81154fe858102906001ff649a11282 # v1.1.3
     - name: Generate job output
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -170,7 +170,6 @@ runs:
       if: ${{ steps.matrix-jobs.outputs.num == strategy.job-total && steps.matrix-jobs.outputs.num-running > 1 }}
       shell: bash
       run: |
-        set -x
         # Wait for running matrix jobs
         start=$(date +%s)
 

--- a/action.yaml
+++ b/action.yaml
@@ -107,7 +107,7 @@ runs:
         jobs="$(jq 'sort_by(.created_at) | reverse | unique_by(.name)' <<<"${jobs}")"
 
         # Reduce size of executed jobs content. Doing this avoids having `bash` fail with
-        # "Argument list too long" when the run contains 50+ jobs (1.
+        # "Argument list too long" when the run contains 50+ jobs.
         jobs="$(jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}")"
 
         if [[ "$RUNNER_DEBUG" -eq 1 ]] || [[ "${{ inputs.debug }}" == "true" ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -105,12 +105,9 @@ runs:
         # Remove older jobs which were re-run
         jobs="$(jq 'sort_by(.created_at) | reverse | unique_by(.name)' <<<"${jobs}")"
 
-        # Reduce size of executed jobs content
-        jobs="$(jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}")"
-
         if [[ "$RUNNER_DEBUG" -eq 1 ]] || [[ "${{ inputs.debug }}" == "true" ]]; then
             echo "Executed jobs:" >&2
-            jq '.' <<<"${jobs}" >&2
+            jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}" >&2
         fi
 
         {

--- a/action.yaml
+++ b/action.yaml
@@ -181,7 +181,7 @@ runs:
             sync_artifact_name="${sync_artifact_prefix:?}-${job_index:?}"
 
             # https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts
-            artifacts="$(gh api -X GET "/repos/{owner}/{repo}/actions/runs/${run_id:?}/artifacts")"
+            artifacts="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs/${run_id:?}/artifacts")"
 
             sync_artifact_exists="$(jq --arg name "${sync_artifact_name:?}" '.artifacts | map(select(.name == $name)) | any' <<<"${artifacts}")"
             if [[ "${sync_artifact_exists}" == "true" ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - id: job
-      uses: beacon-biosignals/job-context@656c4f5d624c5e6b5679e742c179f5f6da90b02d  # v1.1.1
+      uses: beacon-biosignals/job-context@2f92656dba435815b1248b58e472f8721fb8a448 # v1.1.2
     - name: Generate job output
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,8 @@ runs:
   using: composite
   steps:
     - id: job
-      uses: beacon-biosignals/job-context@2f92656dba435815b1248b58e472f8721fb8a448 # v1.1.2
+      # uses: beacon-biosignals/job-context@2f92656dba435815b1248b58e472f8721fb8a448 # v1.1.2
+      uses: beacon-biosignals/job-context@6cdc430ffafdf7b69d31fa7442f30de07e88cc77 # https://github.com/beacon-biosignals/job-context/pull/16
     - name: Generate job output
       shell: bash
       run: |
@@ -93,7 +94,7 @@ runs:
         # here as it has proven to be unreliable and does not include running jobs.
         jobs='[]'
         for attempt in $(seq 1 ${run_attempt}); do
-            attempt_jobs="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${attempt:?}/jobs" --jq '.jobs')"
+            attempt_jobs="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${attempt:?}/jobs" | jq -s '[.[].jobs[]]')"
 
             # Remove job entries which weren't actually executed during this attempt.
             # The GitHub API includes new `job_id`s for each `run_attempt` and we want to
@@ -186,9 +187,9 @@ runs:
             sync_artifact_name="${sync_artifact_prefix:?}-${job_index:?}"
 
             # https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts
-            artifacts="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs/${run_id:?}/artifacts")"
+            artifacts="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs/${run_id:?}/artifacts" | jq -s '[.[].artifacts[]]')"
 
-            sync_artifact_exists="$(jq --arg name "${sync_artifact_name:?}" '.artifacts | map(select(.name == $name)) | any' <<<"${artifacts}")"
+            sync_artifact_exists="$(jq --arg name "${sync_artifact_name:?}" 'map(select(.name == $name)) | any' <<<"${artifacts}")"
             if [[ "${sync_artifact_exists}" == "true" ]]; then
                 remaining_job_ids=("${remaining_job_ids[@]:1}")  # Drop the first element
                 continue

--- a/action.yaml
+++ b/action.yaml
@@ -106,9 +106,13 @@ runs:
         # Remove older jobs which were re-run
         jobs="$(jq 'sort_by(.created_at) | reverse | unique_by(.name)' <<<"${jobs}")"
 
+        # Reduce size of executed jobs content. Doing this avoids having `bash` fail with
+        # "Argument list too long" when the run contains 50+ jobs (1.
+        jobs="$(jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}")"
+
         if [[ "$RUNNER_DEBUG" -eq 1 ]] || [[ "${{ inputs.debug }}" == "true" ]]; then
             echo "Executed jobs:" >&2
-            jq '[.[] | {id, name, run_id, run_attempt, created_at, completed_at, conclusion}]' <<<"${jobs}" >&2
+            jq '.' <<<"${jobs}" >&2
         fi
 
         {


### PR DESCRIPTION
Alternative to #20 to improve support for runs with a large job matrix. Avoids writing to disk. The new integration tests ended up finding a few other issue mentioned [here](https://github.com/beacon-biosignals/matrix-output/pull/21#issuecomment-3993622090).

Depends on:
- https://github.com/beacon-biosignals/job-context/pull/16

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213530670760264